### PR TITLE
Handle the case when the type is null

### DIFF
--- a/src/__tests__/createAction-test.js
+++ b/src/__tests__/createAction-test.js
@@ -6,6 +6,11 @@ describe('createAction()', () => {
   describe('resulting action creator', () => {
     const type = 'TYPE';
 
+    it('should not throw error if type of null is passed', () => {
+      const action = createAction(null);
+      expect(action()).to.deep.equal({type: null});
+    });
+
     it('returns a valid FSA', () => {
       const actionCreator = createAction(type, b => b);
       const foobar = { foo: 'bar' };

--- a/src/createAction.js
+++ b/src/createAction.js
@@ -15,7 +15,7 @@ export default function createAction(type, payloadCreator = identity, metaCreato
       ? head : payloadCreator(head, ...args));
 
   const hasMeta = isFunction(metaCreator);
-  const typeString = type.toString();
+  const typeString = type && type.toString();
 
   const actionCreator = (...args) => {
     const payload = finalPayloadCreator(...args);


### PR DESCRIPTION
When by mistake the type of the action is null, The execution breaks at the library. 
This used to work before https://github.com/reduxactions/redux-actions/commit/bea186f6b2467d3f706b54649b1dd4d6f53ffc98#diff-52ace21827ea0130a413a22cd1697dc8