### PR TITLE
Fix Tutorial.md and README.md code

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ import { createActions, handleActions, combineActions } from 'redux-actions'
 const defaultState = { counter: 10 };
 
 const { increment, decrement } = createActions({
-  INCREMENT: amount => ({ amount }),
-  DECREMENT: amount => ({ amount: -amount })
+  INCREMENT: (amount = 1) => ({ amount }),
+  DECREMENT: (amount = 1) => ({ amount: -amount })
 });
 
 const reducer = handleActions({
-  [combineActions(increment, decrement)](state, { payload: { amount } }) {
+  [combineActions(increment, decrement)]: (state, { payload: { amount } }) {
     return { ...state, counter: state.counter + amount };
   }
 }, defaultState);

--- a/docs/introduction/Tutorial.md
+++ b/docs/introduction/Tutorial.md
@@ -85,6 +85,7 @@ Next we are going to handle that action with `handleAction`. We can provide it o
 
 ```js
 const reducer = handleAction(increment, (state, action) => ({
+  ...state,
   counter: state.counter + 1
 }), defaultState);
 ```
@@ -130,8 +131,8 @@ const {
 } = window.ReduxActions;
 
 const reducer = handleActions({
-  [increment]: ({ counter }) => ({ counter: counter + 1 },
-  [decrement]: ({ counter }) => ({ counter: counter - 1 },
+  [increment]: (state) => ({ ...state, counter: state.counter + 1 },
+  [decrement]: (state) => ({ ...state, counter: state.counter - 1 },
 }, defaultState);
 ```
 
@@ -160,16 +161,16 @@ We can still do better though. What if we want an action like `'INCREMENT_FIVE'`
 
 ```js
 const { increment, decrement } = createActions({
-  'INCREMENT': amount => ({ amount: 1 }),
-  'DECREMENT': amount => ({ amount: -1 })
+  'INCREMENT': (amount = 1) => ({ amount }),
+  'DECREMENT': (amount = 1) => ({ amount: -amount })
 });
 
 const reducer = handleActions({
-  [increment]: ({ counter }, { payload: { amount } }) => {
-    return { counter: counter + amount }
+  [increment]: (state, { payload: { amount } }) => {
+    return { ...state, counter: state.counter + amount }
   },
-  [decrement]: ({ counter }, { payload: { amount } }) => {
-    return { counter: counter - amount }
+  [decrement]: (state, { payload: { amount } }) => {
+    return { ...state, counter: state.counter + amount }
   }
 }, defaultState);
 ```


### PR DESCRIPTION
In Tutorial.md, I did 3 things:

1. Spread the current `state` into the reducer next `state` to keep the code consistent.
2. Fix the `'INCREMENT'` and `'DECREMENT'` action creators , by using a default paramter, so they don't always return `{ amount: 1}` and `{ amount: -1 }` respectively.
3. Change `- amount` to `+ amount` for `'DECREMENT'` reducer since `amount` is negative for the `'DECREMENT'` action.

The commit message has more detail.

In README.md, I did 2 things:

1. Add the default parameter to the action creators.
2. Add a colon to the `reducerMap` to match Tutorial.md. Both ways work but Tutorial.md was changed in [#237](https://github.com/redux-utilities/redux-actions/pull/237#issuecomment-322447782) to be more beginner friendly, since the computed property name mixed with the shorthand method name might not be well known.