### PR TITLE
Migrate project to Webpack 4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,11 @@
 {
   "presets": [
-    "./build/preset-es2015",
+    "env",
     "stage-0"
   ],
   "env": {
     "es": {
+      "presets": [["env", { modules: false }]],
       "plugins": [
         "./build/use-lodash-es"
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ es
 lib
 dist
 .idea
+yarn.lock
 
 # docs generated files
 _book

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "6"
-  - "4"
+  - "8"
+  - "9"
 script:
   - npm run lint
   - npm test

--- a/build/preset-es2015.js
+++ b/build/preset-es2015.js
@@ -1,7 +1,0 @@
-const esOptions = process.env.BABEL_ENV === 'es' ? { modules: false } : {};
-
-module.exports = {
-  presets: [
-    ['es2015', esOptions]
-  ]
-};

--- a/package.json
+++ b/package.json
@@ -37,21 +37,21 @@
   ],
   "author": "Andrew Clark <acdlite@me.com>",
   "bugs": {
-    "url": "https://github.com/acdlite/redux-actions/issues"
+    "url": "https://github.com/redux-utilities/redux-actions/issues"
   },
-  "homepage": "https://github.com/acdlite/redux-actions",
+  "homepage": "https://github.com/redux-utilities/redux-actions",
   "repository": {
     "type": "git",
-    "url": "https://github.com/acdlite/redux-actions.git"
+    "url": "https://github.com/redux-utilities/redux-actions.git"
   },
   "license": "MIT",
   "devDependencies": {
     "babel-cli": "^6.7.7",
     "babel-core": "^6.7.7",
     "babel-eslint": "^6.1.1",
-    "babel-loader": "^6.2.4",
-    "babel-preset-es2015": "^6.6.0",
-    "babel-preset-stage-0": "^6.5.0",
+    "babel-loader": "^7.1.4",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-stage-0": "^6.6.0",
     "babel-register": "^6.7.2",
     "chai": "^3.0.0",
     "cross-env": "^2.0.0",
@@ -63,7 +63,8 @@
     "gitbook-cli": "^2.3.0",
     "mocha": "^2.2.5",
     "rimraf": "^2.5.3",
-    "webpack": "^1.13.1"
+    "webpack": "^4.1.1",
+    "webpack-cli": "^2.0.11"
   },
   "dependencies": {
     "invariant": "^2.2.1",

--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -4,27 +4,6 @@ import path from 'path';
 const { NODE_ENV } = process.env;
 const production = NODE_ENV === 'production';
 
-const plugins = [
-  new webpack.optimize.OccurenceOrderPlugin(),
-  new webpack.DefinePlugin({
-    'process.env.NODE_ENV': JSON.stringify(NODE_ENV)
-  })
-];
-
-if (production) {
-  plugins.push(
-    new webpack.optimize.UglifyJsPlugin({
-      compressor: {
-        pure_getters: true,
-        unsafe: true,
-        unsafe_comps: true,
-        screw_ie8: true,
-        warnings: false
-      }
-    })
-  );
-}
-
 export default {
   entry: path.join(__dirname, 'src/index.js'),
   output: {
@@ -33,8 +12,9 @@ export default {
     library: 'ReduxActions',
     libraryTarget: 'umd'
   },
+  mode: production ? 'production' : 'development',
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.js$/,
         loaders: ['babel-loader'],
@@ -42,5 +22,9 @@ export default {
       }
     ]
   },
-  plugins
+  plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify(NODE_ENV)
+    })
+  ]
 };


### PR DESCRIPTION
Migrate project from Webpack 1 to 4. Due to small code base and rather simple configuration there is not a lot of code that has changed. All tests passed successful on my machine.

I've left few comments in the diff preview to explain few changes in detail.

Also project URLs in `package.json` has been updated and `yarn.lock` has been added to `.gitignore` file.