### PR TITLE
use curry instead of fp/curryN to be compatible with lodash-es

### DIFF
--- a/src/createCurriedAction.js
+++ b/src/createCurriedAction.js
@@ -1,5 +1,5 @@
-import curryN from 'lodash/fp/curryN';
+import curry from 'lodash/curry';
 import createAction from './createAction';
 
 export default (type, payloadCreator) =>
-  curryN(payloadCreator.length, createAction(type, payloadCreator));
+  curry(createAction(type, payloadCreator), payloadCreator.length);

--- a/test/createCurriedAction.test.js
+++ b/test/createCurriedAction.test.js
@@ -1,0 +1,12 @@
+import createCurriedAction from '../src/createCurriedAction';
+
+const type = 'TYPE';
+
+test('returns curried function', () => {
+  const curriedAction = createCurriedAction(type, (a, b) => a + b);
+
+  const a = curriedAction(1);
+  const b = a(2);
+
+  expect(b).toEqual({ payload: 3, type });
+});


### PR DESCRIPTION
Fixes #292

`lodash-es` doesn't include `lodash/fp` and breaks the `es` build. Also add a test for `createCurriedAction`.