### PR TITLE
Make combineActions works with nested handleActions

### DIFF
--- a/src/utils/flattenWhenNode.js
+++ b/src/utils/flattenWhenNode.js
@@ -1,5 +1,5 @@
 import isMap from 'lodash/isMap';
-import { DEFAULT_NAMESPACE } from '../constants';
+import { DEFAULT_NAMESPACE, ACTION_TYPE_DELIMITER } from '../constants';
 import ownKeys from './ownKeys';
 
 function get(key, x) {
@@ -14,9 +14,12 @@ export default predicate =>
     partialFlatActionType = ''
   ) {
     function connectNamespace(type) {
-      return partialFlatActionType
-        ? `${partialFlatActionType}${namespace}${type}`
-        : type;
+      if (!partialFlatActionType) return type;
+      const types = type.toString().split(ACTION_TYPE_DELIMITER);
+      const partials = partialFlatActionType.split(ACTION_TYPE_DELIMITER);
+      return []
+        .concat(...partials.map(p => types.map(t => `${p}${namespace}${t}`)))
+        .join(ACTION_TYPE_DELIMITER);
     }
 
     function connectPrefix(type) {

--- a/test/handleActions.test.js
+++ b/test/handleActions.test.js
@@ -529,3 +529,54 @@ test('works with nested reducerMap and identity handlers', () => {
     message: 'hello'
   });
 });
+
+test('works with combineActions nested', () => {
+  const {
+    app: { counter, sameCounter }
+  } = createActions({
+    APP: {
+      COUNTER: undefined,
+      SAME_COUNTER: undefined
+    }
+  });
+  const { app } = createActions({
+    APP: {
+      COUNTER: {
+        INCREMENT: amount => ({ amount }),
+        DECREMENT: amount => ({ amount: -amount })
+      },
+      SAME_COUNTER: {
+        INCREMENT: amount => ({ amount }),
+        DECREMENT: amount => ({ amount: -amount })
+      }
+    }
+  });
+
+  // NOTE: We should be using combineReducers in production, but this is just a test.
+  const reducer = handleActions(
+    {
+      [combineActions(counter, sameCounter)]: {
+        INCREMENT: ({ counter }, { payload: { amount } }) => ({
+          counter: counter + amount
+        }),
+        DECREMENT: ({ counter }, { payload: { amount } }) => ({
+          counter: counter + amount
+        })
+      }
+    },
+    { counter: 0 }
+  );
+
+  expect(reducer({ counter: 3 }, app.counter.increment(2))).toEqual({
+    counter: 5
+  });
+  expect(reducer({ counter: 10 }, app.counter.decrement(3))).toEqual({
+    counter: 7
+  });
+  expect(reducer({ counter: 3 }, app.sameCounter.increment(2))).toEqual({
+    counter: 5
+  });
+  expect(reducer({ counter: 10 }, app.sameCounter.decrement(3))).toEqual({
+    counter: 7
+  });
+});

--- a/test/handleActions.test.js
+++ b/test/handleActions.test.js
@@ -531,52 +531,28 @@ test('works with nested reducerMap and identity handlers', () => {
 });
 
 test('works with combineActions nested', () => {
+  const { apiCall1, apiCall2 } = createActions('API_CALL_1', 'API_CALL_2');
   const {
-    app: { counter, sameCounter }
+    apiCall1: { loading: apiCallLoading1 },
+    apiCall2: { loading: apiCallLoading2 }
   } = createActions({
-    APP: {
-      COUNTER: undefined,
-      SAME_COUNTER: undefined
-    }
-  });
-  const { app } = createActions({
-    APP: {
-      COUNTER: {
-        INCREMENT: amount => ({ amount }),
-        DECREMENT: amount => ({ amount: -amount })
-      },
-      SAME_COUNTER: {
-        INCREMENT: amount => ({ amount }),
-        DECREMENT: amount => ({ amount: -amount })
-      }
-    }
+    API_CALL_1: { LOADING: undefined },
+    API_CALL_2: { LOADING: undefined }
   });
 
-  // NOTE: We should be using combineReducers in production, but this is just a test.
   const reducer = handleActions(
     {
-      [combineActions(counter, sameCounter)]: {
-        INCREMENT: ({ counter }, { payload: { amount } }) => ({
-          counter: counter + amount
-        }),
-        DECREMENT: ({ counter }, { payload: { amount } }) => ({
-          counter: counter + amount
-        })
+      [combineActions(apiCall1, apiCall2)]: {
+        LOADING: (state, { payload: loading }) => ({ loading })
       }
     },
-    { counter: 0 }
+    { loading: false }
   );
 
-  expect(reducer({ counter: 3 }, app.counter.increment(2))).toEqual({
-    counter: 5
+  expect(reducer({ loading: false }, apiCallLoading1(true))).toEqual({
+    loading: true
   });
-  expect(reducer({ counter: 10 }, app.counter.decrement(3))).toEqual({
-    counter: 7
-  });
-  expect(reducer({ counter: 3 }, app.sameCounter.increment(2))).toEqual({
-    counter: 5
-  });
-  expect(reducer({ counter: 10 }, app.sameCounter.decrement(3))).toEqual({
-    counter: 7
+  expect(reducer({ loading: false }, apiCallLoading2(true))).toEqual({
+    loading: true
   });
 });


### PR DESCRIPTION
Fixes #241 (I used the code @Parakleta suggested)

It allows nesting of actions in `handleActions` after a `combineActions` (very useful for loadings):
```js
const reducer = handleActions(
  {
    [combineActions(apiCall1, apiCall2)]: {
      LOADING: () => ({ loading: true }),
    }
  },
  { loading: false }
);
```

I had some troubles to write a clean test, let me know if you want to improve it.