### PR TITLE
Add sideEffects: false to enable tree shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "sideEffects": false,
   "scripts": {
     "precommit": "lint-staged",
     "format": "prettier --write \"**/*.{js,md}\"",


### PR DESCRIPTION
This PR enables webpack 4 to do tree shaking on es-build.

It adds sideEffects: false to package.json, which tells webpack that imports don't have sideEffects. https://webpack.js.org/guides/tree-shaking/