### PR TITLE
IE11 does not support Array.prototype.includes

### DIFF
--- a/src/handleAction.js
+++ b/src/handleAction.js
@@ -26,7 +26,7 @@ export default function handleAction(type, reducer = identity, defaultState) {
 
   return (state = defaultState, action) => {
     const { type: actionType } = action;
-    if (!actionType || !types.includes(toString(actionType))) {
+    if (!actionType || types.indexOf(toString(actionType)) === -1) {
       return state;
     }
 


### PR DESCRIPTION
https://github.com/redux-utilities/redux-actions/pull/307 broke IE11 due to it not supporting Array.prototype.includes

https://caniuse.com/#feat=array-includes