### PR TITLE
Embed Link to Flux Standard Action

### DIFF
--- a/docs/api/handleAction.md
+++ b/docs/api/handleAction.md
@@ -19,7 +19,7 @@ handleAction(
 )
 ```
 
-Wraps a reducer so that it only handles Flux Standard Actions of a certain type.
+Wraps a reducer so that it only handles [Flux Standard Actions](https://github.com/redux-utilities/flux-standard-action#flux-standard-action) of a certain type.
 
 ```js
 import { handleAction } from 'redux-actions';


### PR DESCRIPTION
Enriches documentation by linking to the [Flux Standard Action](https://github.com/redux-utilities/flux-standard-action#flux-standard-action) README.