### PR TITLE
Update docs with `prefix` and `namespace` example

### DIFF
--- a/docs/api/createAction.md
+++ b/docs/api/createAction.md
@@ -207,6 +207,7 @@ expect(
   meta: { username: 'yangmillstheory', message: 'Hello World' }
 });
 ```
+
 ##### Action prefix
 
 You can prefix each action type by passing a configuration object as the last argument of `createActions`.

--- a/docs/api/createAction.md
+++ b/docs/api/createAction.md
@@ -207,14 +207,20 @@ expect(
   meta: { username: 'yangmillstheory', message: 'Hello World' }
 });
 ```
+##### Action prefix
 
-When using this form, you can pass an object with key `namespace` as the last positional argument (the default is `/`).
+You can prefix each action type by passing a configuration object as the last argument of `createActions`.
 
 ###### EXAMPLE
 
 ```js
-createActions({ ... }, 'INCREMENT', { namespace: '--' })
+createActions({ ... }, 'INCREMENT', {
+  prefix: 'counter', // String used to prefix each type
+  namespace: '--' // Separator between prefix and type.  Default: `/`
+})
 ```
+
+`'INCREMENT'` in this example will be prefixed as `counter--INCREMENT`.
 
 #### `createActions(actionMap, ...identityActions)`{#createactionsactionmap-identityactions}
 

--- a/docs/api/createAction.md
+++ b/docs/api/createAction.md
@@ -6,8 +6,8 @@
     - [`createAction(type, payloadCreator)`](#createactiontype-payloadcreator)
     - [`createAction(type, payloadCreator, metaCreator)`](#createactiontype-payloadcreator-metacreator)
   - [createActions](#createactions)
-    - [`createActions(actionMap)`](#createactionsactionmap)
-    - [`createActions(actionMap, ...identityActions)`](#createactionsactionmap-identityactions)
+    - [`createActions(actionMap[, options])`](#createactionsactionmap)
+    - [`createActions(actionMap, ...identityActions[, options])`](#createactionsactionmap-identityactions)
 
 ## Methods
 
@@ -137,6 +137,7 @@ updateAdminUser({ name: 'Foo' });
 createActions(
   actionMap,
   ?...identityActions,
+  ?options
 )
 ```
 
@@ -146,7 +147,7 @@ Returns an object mapping action types to action creators. The keys of this obje
 import { createActions } from 'redux-actions';
 ```
 
-#### `createActions(actionMap)` {#createactionsactionmap}
+#### `createActions(actionMap[, options])` {#createactionsactionmap}
 
 `actionMap` is an object which can optionally have a recursive data structure, with action types as keys, and whose values **must** be either
 
@@ -208,22 +209,7 @@ expect(
 });
 ```
 
-##### Action prefix
-
-You can prefix each action type by passing a configuration object as the last argument of `createActions`.
-
-###### EXAMPLE
-
-```js
-createActions({ ... }, 'INCREMENT', {
-  prefix: 'counter', // String used to prefix each type
-  namespace: '--' // Separator between prefix and type.  Default: `/`
-})
-```
-
-`'INCREMENT'` in this example will be prefixed as `counter--INCREMENT`.
-
-#### `createActions(actionMap, ...identityActions)`{#createactionsactionmap-identityactions}
+#### `createActions(actionMap, ...identityActions[, options])`{#createactionsactionmap-identityactions}
 
 `identityActions` is an optional list of positional string arguments that are action type strings; these action types will use the identity payload creator.
 
@@ -260,3 +246,18 @@ expect(actionThree(3)).to.deep.equal({
   payload: 3
 });
 ```
+
+#### `createActions(actionMap[, ...identityActions], options)`
+
+You can prefix each action type by passing a configuration object as the last argument of `createActions`.
+
+###### EXAMPLE
+
+```js
+createActions({ ... }, 'INCREMENT', {
+  prefix: 'counter', // String used to prefix each type
+  namespace: '--' // Separator between prefix and type.  Default: `/`
+})
+```
+
+`'INCREMENT'` in this example will be prefixed as `counter--INCREMENT`.

--- a/docs/api/handleAction.md
+++ b/docs/api/handleAction.md
@@ -5,7 +5,7 @@
     - [`handleAction(type, reducer, defaultState)`](#handleactiontype-reducer-defaultstate)
     - [`handleAction(type, reducerMap, defaultState)`](#handleactiontype-reducermap-defaultstate)
   - [handleActions](#handleactions)
-    - [`handleActions(reducerMap, defaultState)`](#handleactionsreducermap-defaultstate)
+    - [`handleActions(reducerMap, defaultState[, options])`](#handleactionsreducermap-defaultstate)
 
 ## Methods
 
@@ -70,13 +70,13 @@ handleActions(reducerMap, defaultState);
 
 Creates multiple reducers using `handleAction()` and combines them into a single reducer that handles multiple actions. Accepts a map where the keys are passed as the first parameter to `handleAction()` (the action type), and the values are passed as the second parameter (either a reducer or reducer map). The map must not be empty.
 
-If `reducerMap` has a recursive structure, its leaves are used as reducers, and the action type for each leaf is the path to that leaf. If a node's only children are `next()` and `throw()`, the node will be treated as a reducer. If the leaf is `undefined` or `null`, the identity function is used as the reducer. Otherwise, the leaf should be the reducer function. When using this form, you can pass an object with key `namespace` as the last positional argument (the default is `/`).
+If `reducerMap` has a recursive structure, its leaves are used as reducers, and the action type for each leaf is the path to that leaf. If a node's only children are `next()` and `throw()`, the node will be treated as a reducer. If the leaf is `undefined` or `null`, the identity function is used as the reducer. Otherwise, the leaf should be the reducer function.
 
 ```js
 import { handleActions } from 'redux-actions';
 ```
 
-#### `handleActions(reducerMap, defaultState)` {#handleactionsreducermap-defaultstate}
+#### `handleActions(reducerMap, defaultState[, options])` {#handleactionsreducermap-defaultstate}
 
 The second parameter `defaultState` is required, and is used when `undefined` is passed to the reducer.
 
@@ -146,4 +146,21 @@ const reducer = handleActions(
   ]),
   { counter: 0 }
 );
+```
+
+#### `handleActions(actionMap[, defaultState], options)`
+
+You can prefix each action type by passing a configuration object as the last argument of `handleActions`.
+
+###### EXAMPLE
+
+```js
+const options = {
+  prefix: 'counter', // String used to prefix each type
+  namespace: '--' // Separator between prefix and type.  Default: `/`
+}
+
+createActions({ ... }, 'INCREMENT', options)
+
+handleActions({ ... }, defaultState, options)
 ```


### PR DESCRIPTION
Documents the `prefix` option introduced in #263 in https://redux-actions.js.org/api/createaction.