### PR TITLE
Bugfix: Prevent double-prefixing when using `combineActions`

### DIFF
--- a/src/utils/flattenWhenNode.js
+++ b/src/utils/flattenWhenNode.js
@@ -19,7 +19,11 @@ export default predicate =>
     }
 
     function connectPrefix(type) {
-      if (partialFlatActionType || !prefix) {
+      if (
+        partialFlatActionType ||
+        !prefix ||
+        (prefix && new RegExp(`^${prefix}${namespace}`).test(type))
+      ) {
         return type;
       }
 

--- a/test/combineActions.test.js
+++ b/test/combineActions.test.js
@@ -32,6 +32,26 @@ test('returns a stringifiable object', () => {
   );
 });
 
+test('handles prefixed action types', () => {
+  const options = { prefix: 'my-custom-prefix' };
+  const { action1, action2 } = createActions('ACTION_1', 'ACTION_2', options);
+
+  expect(
+    combineActions(
+      'my-custom-prefix/ACTION_1',
+      'my-custom-prefix/ACTION_2'
+    ).toString()
+  ).toBe('my-custom-prefix/ACTION_1||my-custom-prefix/ACTION_2');
+  expect(combineActions(action1, action2).toString()).toBe(
+    'my-custom-prefix/ACTION_1||my-custom-prefix/ACTION_2'
+  );
+  expect(
+    combineActions(action1, action2, 'my-custom-prefix/ACTION_3').toString()
+  ).toBe(
+    'my-custom-prefix/ACTION_1||my-custom-prefix/ACTION_2||my-custom-prefix/ACTION_3'
+  );
+});
+
 test('should throw error if actions is empty', () => {
   expect(() => combineActions()).toThrow(
     'Expected action types to be strings, symbols, or action creators'

--- a/test/handleActions.test.js
+++ b/test/handleActions.test.js
@@ -557,7 +557,7 @@ test('works with combineActions nested', () => {
   });
 });
 
-test.only('works with a prefix and namespace', () => {
+test('works with a prefix and namespace', () => {
   const { increment, decrement } = createActions(
     {
       INCREMENT: [amount => ({ amount }), amount => ({ key: 'value', amount })],

--- a/test/handleActions.test.js
+++ b/test/handleActions.test.js
@@ -556,3 +556,36 @@ test('works with combineActions nested', () => {
     loading: true
   });
 });
+
+test.only('works with a prefix and namespace', () => {
+  const { increment, decrement } = createActions(
+    {
+      INCREMENT: [amount => ({ amount }), amount => ({ key: 'value', amount })],
+      DECREMENT: amount => ({ amount: -amount })
+    },
+    { prefix: 'my-custom-prefix', namespace: '--' }
+  );
+
+  // NOTE: We should be using combineReducers in production, but this is just a test.
+  const reducer = handleActions(
+    {
+      [combineActions(increment, decrement)]: (
+        { counter },
+        { payload: { amount } }
+      ) => ({
+        counter: counter + amount
+      })
+    },
+    { counter: 0 },
+    { prefix: 'my-custom-prefix', namespace: '--' }
+  );
+
+  expect(String(increment)).toBe('my-custom-prefix--INCREMENT');
+
+  expect(reducer({ counter: 3 }, increment(2))).toEqual({
+    counter: 5
+  });
+  expect(reducer({ counter: 10 }, decrement(3))).toEqual({
+    counter: 7
+  });
+});


### PR DESCRIPTION
Using the `prefix` option in conjunction with `combineActions` will prefix the combined action type again.  For example:
```js
const options = { prefix: 'my-prefix' };
const { action1, action2 } = createActions('ACTION_1', 'ACTION_2', options)

const combinedActionType = combineActions(action1, action2).toString()

console.log(combinedActionType)
// "my-prefix/my-prefix/ACTION_1||my-prefix/ACTION_2"
```

This PR fixes the issue by checking if the action type string already starts with the prefix + namespace.