### PR TITLE
IE11 does not support String.prototype.includes

### DIFF
--- a/src/utils/camelCase.js
+++ b/src/utils/camelCase.js
@@ -3,9 +3,9 @@ import camelCase from 'to-camel-case';
 const namespacer = '/';
 
 export default type =>
-  type.includes(namespacer)
-    ? type
+  type.indexOf(namespacer) === -1
+    ? camelCase(type)
+    : type
         .split(namespacer)
         .map(camelCase)
-        .join(namespacer)
-    : camelCase(type);
+        .join(namespacer);


### PR DESCRIPTION
#306 broke IE11 due to it's not supporting `String.prototype.includes`
