### PR TITLE
fix(type): fix type detection error

### DIFF
--- a/src/createAction.js
+++ b/src/createAction.js
@@ -1,7 +1,7 @@
 import invariant from 'invariant';
 import isFunction from './utils/isFunction';
 import identity from './utils/identity';
-import isNull from './utils/isNull';
+import isNil from './utils/isNil';
 
 export default function createAction(
   type,
@@ -9,12 +9,12 @@ export default function createAction(
   metaCreator
 ) {
   invariant(
-    isFunction(payloadCreator) || isNull(payloadCreator),
+    isFunction(payloadCreator) || isNill(payloadCreator),
     'Expected payloadCreator to be a function, undefined or null'
   );
 
   const finalPayloadCreator =
-    isNull(payloadCreator) || payloadCreator === identity
+    isNil(payloadCreator) || payloadCreator === identity
       ? identity
       : (head, ...args) =>
           head instanceof Error ? head : payloadCreator(head, ...args);


### PR DESCRIPTION
1. Previously only judged `null`, but did not judge `undefined`
2. `null == undefined => true`, `null === undefined => false`